### PR TITLE
Add timing code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,11 @@
+cargo-features = ["default-run"]
+
 [package]
 name = "fwop"
 version = "0.1.0"
 authors = ["C Jones <code@calebjones.net>"]
 edition = "2018"
+default-run = "solve"
 
 [dependencies]
 

--- a/src/bin/solve.rs
+++ b/src/bin/solve.rs
@@ -41,11 +41,11 @@ fn generate_fwopcache<P: AsRef<Path>>(path: P) -> io::Result<File> {
         (write_end - start).as_float_secs()
     );
     println!(
-        "Generated: {:.02} seconds",
+        "Generated: {:6.02} seconds",
         generate_end.duration_since(start).as_float_secs()
     );
     println!(
-        "    Wrote: {:.02} seconds",
+        "    Wrote: {:6.02} seconds",
         write_end.duration_since(generate_end).as_float_secs()
     );
     file.flush()?;


### PR DESCRIPTION
Fixes #7 

Example:
```
No game cache found, generating...
Saved 8388608 cache entries in 78.53 seconds.
Generated:   8.58 seconds
    Wrote:  69.94 seconds
```